### PR TITLE
fix(scroll area) docs padding

### DIFF
--- a/src/docs/previews/scroll-area/always/tailwind/index.svelte
+++ b/src/docs/previews/scroll-area/always/tailwind/index.svelte
@@ -12,11 +12,11 @@
 
 <div
 	use:melt={$root}
-	class="relative h-72 w-56 overflow-hidden rounded-md border border-neutral-700 bg-neutral-800/90 p-3 text-white shadow-lg"
+	class="relative h-72 w-56 overflow-hidden rounded-md border border-neutral-700 bg-neutral-800/90 text-white shadow-lg"
 >
 	<div use:melt={$viewport} class="h-full w-full rounded-[inherit]">
 		<div use:melt={$content}>
-			<div class="p-4">
+			<div class="p-7">
 				<h4 class="mb-4 font-semibold leading-none">Endless Flavors</h4>
 				{#each flavors as flavor (flavor)}
 					<div class="text-sm">

--- a/src/docs/previews/scroll-area/auto/tailwind/index.svelte
+++ b/src/docs/previews/scroll-area/auto/tailwind/index.svelte
@@ -29,11 +29,11 @@
 <div class="flex flex-col items-center gap-4 sm:flex-row">
 	<div
 		use:melt={$rootA}
-		class="relative h-72 w-56 overflow-hidden rounded-md border border-neutral-700 bg-neutral-800/90 p-3 text-white shadow-lg"
+		class="relative h-72 w-56 overflow-hidden rounded-md border border-neutral-700 bg-neutral-800/90 text-white shadow-lg"
 	>
 		<div use:melt={$viewportA} class="h-full w-full rounded-[inherit]">
 			<div use:melt={$contentA}>
-				<div class="p-4">
+				<div class="p-7">
 					<h4 class="mb-4 font-semibold leading-none">Endless Flavors</h4>
 					{#each flavors as flavor (flavor)}
 						<div class="text-sm">
@@ -58,12 +58,12 @@
 
 	<div
 		use:melt={$root}
-		class="relative h-72 w-56 overflow-hidden rounded-md border border-neutral-700 bg-neutral-800/90 p-3 text-white shadow-lg"
+		class="relative h-72 w-56 overflow-hidden rounded-md border border-neutral-700 bg-neutral-800/90 text-white shadow-lg"
 		style:height="{height}px"
 	>
 		<div use:melt={$viewport} class="h-full w-full rounded-[inherit]">
 			<div use:melt={$content}>
-				<div class="p-4">
+				<div class="p-7">
 					<h4 class="mb-4 font-semibold leading-none">A Few Flavors</h4>
 					{#each flavors.slice(0, 5) as flavor (flavor)}
 						<div class="text-sm">

--- a/src/docs/previews/scroll-area/hover/tailwind/index.svelte
+++ b/src/docs/previews/scroll-area/hover/tailwind/index.svelte
@@ -12,11 +12,11 @@
 
 <div
 	use:melt={$root}
-	class="relative h-72 w-56 overflow-hidden rounded-md border border-neutral-700 bg-neutral-800/90 p-3 text-white shadow-lg"
+	class="relative h-72 w-56 overflow-hidden rounded-md border border-neutral-700 bg-neutral-800/90 text-white shadow-lg"
 >
 	<div use:melt={$viewport} class="h-full w-full rounded-[inherit]">
 		<div use:melt={$content}>
-			<div class="p-4">
+			<div class="p-7">
 				<h4 class="mb-4 font-semibold leading-none">Endless Flavors</h4>
 				{#each flavors as flavor (flavor)}
 					<div class="text-sm">

--- a/src/docs/previews/scroll-area/scroll/tailwind/index.svelte
+++ b/src/docs/previews/scroll-area/scroll/tailwind/index.svelte
@@ -12,11 +12,11 @@
 
 <div
 	use:melt={$root}
-	class="relative h-72 w-56 overflow-hidden rounded-md border border-neutral-700 bg-neutral-800/90 p-3 text-white shadow-lg"
+	class="relative h-72 w-56 overflow-hidden rounded-md border border-neutral-700 bg-neutral-800/90 text-white shadow-lg"
 >
 	<div use:melt={$viewport} class="h-full w-full rounded-[inherit]">
 		<div use:melt={$content}>
-			<div class="p-4">
+			<div class="p-7">
 				<h4 class="mb-4 font-semibold leading-none">Endless Flavors</h4>
 				{#each flavors as flavor (flavor)}
 					<div class="text-sm">


### PR DESCRIPTION
fixed not being able to scroll while pointer is over the root because of the padding in the root.

basically you shouldn't add padding to the `root` because you won't be able to scroll the container if your pointer is over the root's padding. the padding should only be applied to the `content`

### Before (I added the red to show where the padding is)

https://github.com/huntabyte/melt-ui/assets/53095479/a58b56ac-1506-4f00-af5f-fd14a9355087

### After

https://github.com/huntabyte/melt-ui/assets/53095479/00957f84-531c-4015-89e7-a97def72b8bb
