### PR TITLE
fix(scrollarea) firefox pointer events

### DIFF
--- a/src/lib/builders/scroll-area/scrollbars.ts
+++ b/src/lib/builders/scroll-area/scrollbars.ts
@@ -219,8 +219,13 @@ export function createHoverScrollbarAction(state: ScrollAreaState) {
 				 * Firefox triggers pointerleave events if you tab away from the window
 				 * without moving the pointer, so we use mouseenter/mouseleave instead
 				 * which works as expected.
+				 *
+				 * In Firefox, mouseenter is not triggered if the pointer was over the scroll area 
+				 * before events were loaded and then starts moving, 
+				 * so we use pointerenter which works as expected.
 				 */
 				unsubScrollAreaListeners = executeCallbacks(
+					addEventListener(scrollAreaEl, 'pointerenter', handlePointerEnter),
 					addEventListener(scrollAreaEl, 'mouseenter', handlePointerEnter),
 					addEventListener(scrollAreaEl, 'mouseleave', handlePointerLeave)
 				);


### PR DESCRIPTION
In Firefox, if the pointer was already over the scroll area before the event listeners are added, and then you start moving your pointer, the scroll thumb still doesn't show. This is because the `mouseenter` never fires on Firefox in this specific situation. 

This was fixed by adding the `pointerenter` event listener on Firefox. 

### Before

https://github.com/huntabyte/melt-ui/assets/53095479/c4d3ae56-ef4c-443a-b8c7-1223588fcb82



### After
https://github.com/huntabyte/melt-ui/assets/53095479/cf547c05-5fdc-47dc-bd09-ce6e6b81644d




Note that we need both the `pointerenter` and `mouseenter` event listeners on Firefox.
`pointerenter` is needed for the above issue.
`mouseenter` is needed for when you tab away from the window without moving the pointer, and then tabbing back. In this situation, `pointerenter` doesn't get triggered.